### PR TITLE
배우 cache 테이블 구현

### DIFF
--- a/Movietalk/src/main/java/com/sec/movietalk/actor/dto/ActorCache.java
+++ b/Movietalk/src/main/java/com/sec/movietalk/actor/dto/ActorCache.java
@@ -1,0 +1,58 @@
+package com.sec.movietalk.actor.dto;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "actor_cache")
+public class ActorCache {
+    @Id
+    private Long id;
+
+    private String name;
+
+    private Integer gender;
+
+    @Column(name = "profile_path")
+    private String profilePath;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getGender() {
+        return gender;
+    }
+
+    public void setGender(Integer gender) {
+        this.gender = gender;
+    }
+
+    public String getProfilePath() {
+        return profilePath;
+    }
+
+    public void setProfilePath(String profilePath) {
+        this.profilePath = profilePath;
+    }
+}

--- a/Movietalk/src/main/java/com/sec/movietalk/actor/dto/PersonResponse.java
+++ b/Movietalk/src/main/java/com/sec/movietalk/actor/dto/PersonResponse.java
@@ -1,0 +1,15 @@
+package com.sec.movietalk.actor.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class PersonResponse {
+
+    private Long id;
+    private String name;
+    private Integer gender;
+
+    @JsonProperty("profile_path")
+    private String profilePath;
+}

--- a/Movietalk/src/main/java/com/sec/movietalk/actor/repository/ActorCacheRepository.java
+++ b/Movietalk/src/main/java/com/sec/movietalk/actor/repository/ActorCacheRepository.java
@@ -1,0 +1,8 @@
+package com.sec.movietalk.actor.repository;
+
+import com.sec.movietalk.actor.dto.ActorCache;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActorCacheRepository extends JpaRepository<ActorCache, Long> {
+    boolean existsById(Long id);
+}

--- a/Movietalk/src/main/java/com/sec/movietalk/actor/service/ActorCacheService.java
+++ b/Movietalk/src/main/java/com/sec/movietalk/actor/service/ActorCacheService.java
@@ -1,0 +1,21 @@
+package com.sec.movietalk.actor.service;
+
+import com.sec.movietalk.actor.dto.ActorCache;
+import com.sec.movietalk.actor.repository.ActorCacheRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ActorCacheService {
+    private final ActorCacheRepository repository;
+
+    public ActorCacheService(ActorCacheRepository repository) {
+        this.repository = repository;
+    }
+
+    public void saveIfNotExists(Long id, String name, Integer gender, String profilePath) {
+        if (!repository.existsById(id)) {
+            ActorCache actor = new ActorCache(id, name, gender, profilePath);
+            repository.save(actor);
+        }
+    }
+}


### PR DESCRIPTION
배우 cache 테이블 구현 
[ ActorController ]
- 이미 저장된 배우인지 확인 후 actor_cache 테이블에 저장 
- 저장 값 (id, name, gender, profile_path)
[ActorCahe] DTO 구현
[ActorCacheRepository] 구현
[ActorCacheService] 구현